### PR TITLE
Support solver api change

### DIFF
--- a/Recorder.php
+++ b/Recorder.php
@@ -18,6 +18,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\Solver;
+use Composer\IO\NullIO;
 use Composer\Package\Package;
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\PlatformRepository;
@@ -90,7 +91,7 @@ class Recorder
             $request->install($package->getName());
         }
 
-        $solver = new Solver(new DefaultPolicy(), $pool, $toRepo);
+        $solver = new Solver(new DefaultPolicy(), $pool, $toRepo, new NullIO());
 
         return $solver->solve($request);
     }


### PR DESCRIPTION
Recent versions of composer require a 4th argument in the solver constructor (already fixed in claroline/Distribution, added here for compatibility).
